### PR TITLE
Zoom/rotate fixes + pop-up on list view

### DIFF
--- a/thebikekollective/lib/components/create_map_body.dart
+++ b/thebikekollective/lib/components/create_map_body.dart
@@ -134,7 +134,7 @@ class _CreateMapBody extends State<CreateMapBody>
 
   void _zoom() {
     currentZoom = currentZoom - 1;
-    mapController!.move(currentCenter, currentZoom);
+    mapController!.move(mapController!.center, currentZoom);
   }
 
   // This is pretty much entirely from the flutter_map's
@@ -211,7 +211,7 @@ class _CreateMapBody extends State<CreateMapBody>
                       zoom: currentZoom,
                       // Conzar! You can disable rotation using this,
                       // but try not to take the easy way out:
-                      interactiveFlags: InteractiveFlag.all,
+                      interactiveFlags: InteractiveFlag.all & ~InteractiveFlag.rotate,
                       onTap: (a, b) {
                         _popupLayerController.hideAllPopups();
                       }

--- a/thebikekollective/lib/components/list_view_body.dart
+++ b/thebikekollective/lib/components/list_view_body.dart
@@ -335,7 +335,21 @@ class _ListViewBodyState extends State<ListViewBody> {
               postThirdLineText('${post.street}'),
             ]),
             trailing: Image(image: NetworkImage(post.imageURL)),
-            onTap: () {}));
+            onTap: () {
+              showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  return AlertDialog(
+                    title: alertTitleNeutral("Too Far"),
+                    content: alertTextNeutral(
+                        "You need to be within 0.1 mi. to start a ride."),
+                    actions: [
+                      okButton(),
+                    ],
+                  );
+                },
+              );
+            }));
   }
 
   List<PostTile> postBuilder(
@@ -671,6 +685,22 @@ class _ListViewBodyState extends State<ListViewBody> {
     );
   }
 
+  Widget okButton() {
+    return ElevatedButton(
+      child: FormattedText(
+        text: 'Dismiss',
+        size: s_fontSizeSmall,
+        color: Colors.white,
+        font: s_font_IBMPlexSans,
+        weight: FontWeight.bold,
+      ),
+      style: ElevatedButton.styleFrom(primary: Color(s_declineRed)),
+      onPressed: () {
+        Navigator.of(context).pop();
+      },
+    );
+  }
+
   Widget alertTitle(String text) {
     return FormattedText(
       text: text,
@@ -688,6 +718,24 @@ class _ListViewBodyState extends State<ListViewBody> {
       color: Color(s_jungleGreen),
       font: s_font_BonaNova,
       weight: FontWeight.bold,
+    );
+  }
+
+  Widget alertTitleNeutral(String text) {
+    return FormattedText(
+      text: text,
+      size: s_fontSizeMedium,
+      font: s_font_IBMPlexSans,
+      weight: FontWeight.bold,
+    );
+  }
+
+  Widget alertTextNeutral(String text) {
+    return FormattedText(
+      text: text,
+      size: s_fontSizeSmall,
+      font: s_font_IBMPlexSans,
+      weight: FontWeight.w500,
     );
   }
 

--- a/thebikekollective/lib/components/list_view_body.dart
+++ b/thebikekollective/lib/components/list_view_body.dart
@@ -696,7 +696,7 @@ class _ListViewBodyState extends State<ListViewBody> {
       ),
       style: ElevatedButton.styleFrom(primary: Color(s_declineRed)),
       onPressed: () {
-        Navigator.of(context).pop();
+        Navigator.of(context, rootNavigator: true).pop('dialog');
       },
     );
   }


### PR DESCRIPTION
Couple of basic changes:
- Zoom button fixed to zoom out based on user's location (as opposed to a fixed location).
- Map rotation disabled as it messes up the on-screen elements.
- Pop-up added to List View to let users know a bike is too far away if they click a disabled one.